### PR TITLE
hide windows in unattended mode

### DIFF
--- a/window.cc
+++ b/window.cc
@@ -22,6 +22,7 @@
 #include "RECTWrapper.h"
 #include "msg.h"
 #include "resource.h"
+#include "state.h"
 
 ATOM Window::WindowClassAtom = 0;
 HINSTANCE Window::AppInstance = NULL;
@@ -227,6 +228,10 @@ Window::CenterWindow ()
   int WindowWidth, WindowHeight;
   POINT p;
 
+  if(unattended_mode){
+	  ShowWindow(WindowHandle, SW_MINIMIZE);
+	  return;
+  }
   // Get the window rectangle
   WindowRect = GetWindowRect ();
 


### PR DESCRIPTION
I don't know if this change follow guidelines,
but it allows to keep GUI away from user while using -q or --quiet-mode.

Windows are minimized when window centering function is called in unattended_mode.
I hope someone will find a better way to disable GUI for quiet auto-install.